### PR TITLE
Missed getter/setted

### DIFF
--- a/src/Gitlab/Models/User.php
+++ b/src/Gitlab/Models/User.php
@@ -350,7 +350,21 @@ class User implements ResponseClassInterface
     {
         $this->website_url = $website_url;
     }
+   
+    /**
+     * @return mixed
+     */
+    public function getAvatarUrl()
+    {
+        return $this->avatar_url;
+    }
 
-
+    /**
+     * @param string $avatar_url
+     */
+    public function setAvatarUrl($avatar_url)
+    {
+	$this->avatar_url = $avatar_url;
+    }
 
 }


### PR DESCRIPTION
Missed get/set for Gitlab\Models\User::avatar_url
